### PR TITLE
Fixed path to CODING_STYLE.md in copilot-instructions.md

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -14,7 +14,7 @@ It is inspired by the Windows Task Manager but targets Linux and aims to expose 
 
 ## Coding style
 
-Follow the guidelines in [CODING_STYLE.md](../CODING_STYLE.md).
+Follow the guidelines in [CODING_STYLE.md](../src/CODING_STYLE.md).
 
 ## Important conventions
 


### PR DESCRIPTION
In the chapter "[Coding style](https://github.com/benapetr/TuxManager/blob/master/.github/copilot-instructions.md#coding-style)" is a link to the file "../CODING_STYLE.md". Unfortunately this file doesn't exist.
The link probably should point to "../src/CODING_STYLE.md" instead.