### PR TITLE
Add multi-GPU detection and AMD DRM engine support

### DIFF
--- a/src/perf/gpudetailwidget.cpp
+++ b/src/perf/gpudetailwidget.cpp
@@ -293,14 +293,17 @@ void GpuDetailWidget::onUpdated()
     const qint64 dedicatedUsedMiB = this->m_provider->GpuMemUsedMiB(this->m_gpuIndex);
     const qint64 dedicatedTotalMiB = this->m_provider->GpuMemTotalMiB(this->m_gpuIndex);
 
-    // Best-effort approximation used by task-manager-like UIs on Linux where
-    // shared GPU accounting is usually not exposed by common tooling.
-    const qint64 sharedTotalMiB = qMax<qint64>(0, this->m_provider->MemTotalKb() / 1024 / 2);
-    const qint64 sharedUsedMiB = 0;
-
-    this->m_sharedMemHistory.append(0.0);
-    while (this->m_sharedMemHistory.size() > HISTORY_SIZE)
-        this->m_sharedMemHistory.removeFirst();
+    qint64 sharedTotalMiB = this->m_provider->GpuSharedMemTotalMiB(this->m_gpuIndex);
+    qint64 sharedUsedMiB  = this->m_provider->GpuSharedMemUsedMiB(this->m_gpuIndex);
+    const bool hasSharedData = (sharedTotalMiB > 0);
+    if (!hasSharedData)
+    {
+        sharedTotalMiB = qMax<qint64>(0, this->m_provider->MemTotalKb() / 1024 / 2);
+        sharedUsedMiB  = 0;
+        this->m_sharedMemHistory.append(0.0);
+        while (this->m_sharedMemHistory.size() > HISTORY_SIZE)
+            this->m_sharedMemHistory.removeFirst();
+    }
 
     const qint64 gpuUsedMiB = dedicatedUsedMiB + sharedUsedMiB;
     const qint64 gpuTotalMiB = dedicatedTotalMiB + sharedTotalMiB;
@@ -346,7 +349,10 @@ void GpuDetailWidget::onUpdated()
     this->m_dedicatedMemGraph->SetPercentTooltipAbsolute(static_cast<double>(dedicatedTotalMiB) / 1024.0, tr("GB"), 2);
     this->m_dedicatedMemGraphMaxLabel->setText(formatMemMib(dedicatedTotalMiB));
 
-    this->m_sharedMemGraph->SetHistoryRef(this->m_sharedMemHistory, 100.0);
+    const QVector<double> &sharedHistory = hasSharedData
+        ? this->m_provider->GpuSharedMemHistory(this->m_gpuIndex)
+        : this->m_sharedMemHistory;
+    this->m_sharedMemGraph->SetHistoryRef(sharedHistory, 100.0);
     this->m_sharedMemGraph->SetPercentTooltipAbsolute(static_cast<double>(sharedTotalMiB) / 1024.0, tr("GB"), 2);
     this->m_sharedMemGraphMaxLabel->setText(formatMemMib(sharedTotalMiB));
 

--- a/src/perf/perfdataprovider.cpp
+++ b/src/perf/perfdataprovider.cpp
@@ -27,7 +27,10 @@
 #include <QHash>
 #include <QRegularExpression>
 #include <QStringList>
+#include <QSysInfo>
 #include <dlfcn.h>
+#include <linux/limits.h>
+#include <unistd.h>
 #include <ifaddrs.h>
 #include <netdb.h>
 #include <netinet/in.h>
@@ -474,6 +477,28 @@ const QVector<double> &PerfDataProvider::GpuCopyRxHistory(int i) const
     if (i < 0 || i >= this->m_gpus.size())
         return empty;
     return this->m_gpus.at(i).copyRxHistory;
+}
+
+qint64 PerfDataProvider::GpuSharedMemUsedMiB(int i) const
+{
+    if (i < 0 || i >= this->m_gpus.size())
+        return 0;
+    return this->m_gpus.at(i).sharedMemUsedMiB;
+}
+
+qint64 PerfDataProvider::GpuSharedMemTotalMiB(int i) const
+{
+    if (i < 0 || i >= this->m_gpus.size())
+        return 0;
+    return this->m_gpus.at(i).sharedMemTotalMiB;
+}
+
+const QVector<double> &PerfDataProvider::GpuSharedMemHistory(int i) const
+{
+    static const QVector<double> empty;
+    if (i < 0 || i >= this->m_gpus.size())
+        return empty;
+    return this->m_gpus.at(i).sharedMemHistory;
 }
 
 int PerfDataProvider::GpuEngineCount(int gpuIndex) const
@@ -1571,8 +1596,12 @@ bool PerfDataProvider::sampleNvml()
         g.engines = engines;
         seenIds.insert(id);
     }
+    // Zero-out stale NVML GPUs that disappeared between ticks (e.g. hot-unplug).
+    // Only touch entries that were previously produced by NVML (backend == "nvml").
     for (GpuSample &g : this->m_gpus)
     {
+        if (g.backend != QLatin1String("NVML"))
+            continue;
         if (!seenIds.contains(g.id))
         {
             g.utilPct = 0.0;
@@ -1618,12 +1647,19 @@ void PerfDataProvider::detectDrmCards()
 
         DrmCard card;
         card.vendor = vendorStr;
+        card.cardNodePath = QStringLiteral("/dev/dri/") + entry;
 
         // Stable identifier: the PCI address resolved from the sysfs symlink.
         const QString canonical = QFileInfo(devPath).canonicalFilePath();
         card.id = QFileInfo(canonical).fileName();
         if (card.id.isEmpty())
             card.id = entry;
+
+        // Detect the render node for this card (used by fdinfo engine scanner).
+        const QStringList renderNodes = QDir(devPath + "/drm")
+                                            .entryList({"renderD*"}, QDir::Dirs);
+        if (!renderNodes.isEmpty())
+            card.renderNodePath = QStringLiteral("/dev/dri/") + renderNodes.first();
 
         // First hwmon sub-directory holds temperature and driver name.
         const QStringList hwmons = QDir(devPath + "/hwmon")
@@ -1637,6 +1673,8 @@ void PerfDataProvider::detectDrmCards()
                 card.tempPath = tp;
         }
 
+        // Driver version: try module version first, fall back to kernel version
+        // for in-tree drivers (e.g. amdgpu ships inside the kernel).
         if (!card.driverName.isEmpty())
         {
             const QString ver = readSysTextFile(
@@ -1644,10 +1682,25 @@ void PerfDataProvider::detectDrmCards()
             if (!ver.isEmpty())
                 card.driverVersion = ver;
         }
+        if (card.driverVersion.isEmpty())
+            card.driverVersion = QSysInfo::kernelVersion();
 
         const QString busyPath = devPath + "/gpu_busy_percent";
         if (QFileInfo::exists(busyPath))
             card.busyPath = busyPath;
+
+        // Dynamically detect all *_busy_percent engine files.
+        const QStringList busyFiles = QDir(devPath).entryList(
+            {"*_busy_percent"}, QDir::Files);
+        for (const QString &f : busyFiles)
+        {
+            if (f == QLatin1String("gpu_busy_percent"))
+                continue;  // handled separately as overall utilisation
+
+            static const QLatin1String suffix("_busy_percent");
+            const QString key = f.chopped(suffix.size());
+            card.engineBusyPaths.append({key, devPath + "/" + f});
+        }
 
         const QString vramT = devPath + "/mem_info_vram_total";
         const QString vramU = devPath + "/mem_info_vram_used";
@@ -1657,13 +1710,27 @@ void PerfDataProvider::detectDrmCards()
             card.vramUsedPath  = vramU;
         }
 
+        const QString gttT = devPath + "/mem_info_gtt_total";
+        const QString gttU = devPath + "/mem_info_gtt_used";
+        if (QFileInfo::exists(gttT) && QFileInfo::exists(gttU))
+        {
+            card.gttTotalPath = gttT;
+            card.gttUsedPath  = gttU;
+        }
+
         this->m_drmCards.append(card);
     }
 }
 
 bool PerfDataProvider::sampleDrm()
 {
-    for (const DrmCard &card : std::as_const(this->m_drmCards))
+    const qint64 fdInfoElapsedNs = this->m_gpuFdInfoTimerStarted
+                                   ? this->m_gpuFdInfoTimer.nsecsElapsed()
+                                   : 0;
+
+    ++this->m_gpuFdInfoRescanCounter;
+
+    for (DrmCard &card : this->m_drmCards)
     {
         int gpuIdx = -1;
         for (int j = 0; j < this->m_gpus.size(); ++j)
@@ -1725,16 +1792,210 @@ bool PerfDataProvider::sampleDrm()
             g.memUsedMiB  = okU ? used  / (1024LL * 1024LL) : 0;
         }
 
+        if (!card.gttTotalPath.isEmpty())
+        {
+            bool okT = false, okU = false;
+            const qint64 total = readSysTextFile(card.gttTotalPath).trimmed().toLongLong(&okT);
+            const qint64 used  = readSysTextFile(card.gttUsedPath).trimmed().toLongLong(&okU);
+            g.sharedMemTotalMiB = okT ? total / (1024LL * 1024LL) : 0;
+            g.sharedMemUsedMiB  = okU ? used  / (1024LL * 1024LL) : 0;
+        }
+
         const double memPct = (g.memTotalMiB > 0)
                               ? static_cast<double>(g.memUsedMiB)
                                 / static_cast<double>(g.memTotalMiB) * 100.0
                               : 0.0;
         appendHistory(g.memUsageHistory, memPct);
+
+        const double sharedPct = (g.sharedMemTotalMiB > 0)
+                                 ? static_cast<double>(g.sharedMemUsedMiB)
+                                   / static_cast<double>(g.sharedMemTotalMiB) * 100.0
+                                 : 0.0;
+        appendHistory(g.sharedMemHistory, sharedPct);
+
         appendHistory(g.copyTxHistory,   0.0);
         appendHistory(g.copyRxHistory,   0.0);
+
+        // ── Engine data ──────────────────────────────────────────────────────
+        QHash<QString, GpuEngineSample> oldEngines;
+        for (const GpuEngineSample &e : g.engines)
+            oldEngines.insert(e.key, e);
+
+        QVector<GpuEngineSample> engines;
+        auto addEngine = [&](const QString &key, const QString &label, double pct)
+        {
+            GpuEngineSample eng = oldEngines.value(key);
+            eng.key   = key;
+            eng.label = label;
+            eng.pct   = qBound(0.0, pct, 100.0);
+            appendHistory(eng.history, eng.pct);
+            engines.append(eng);
+        };
+
+        if (!card.busyPath.isEmpty())
+            addEngine("gfx", "GFX", g.utilPct);
+
+        // Dynamic sysfs engines (vcn_busy_percent, jpeg_busy_percent, …).
+        for (const auto &ep : card.engineBusyPaths)
+        {
+            bool ok = false;
+            const int pct = readSysTextFile(ep.second).trimmed().toInt(&ok);
+            addEngine(ep.first, ep.first.toUpper(), ok ? static_cast<double>(pct) : 0.0);
+        }
+
+        // fdinfo-based engines (Compute, etc.) — cumulative ns, need delta.
+        if (!card.renderNodePath.isEmpty())
+        {
+            const QHash<QString, qint64> curNs = this->scanDrmFdInfoEngines(card);
+            QSet<QString> sysFsKeys;
+            sysFsKeys.insert(QStringLiteral("gfx"));
+            for (const auto &ep : card.engineBusyPaths)
+                sysFsKeys.insert(ep.first);
+
+            for (auto it = curNs.cbegin(); it != curNs.cend(); ++it)
+            {
+                if (sysFsKeys.contains(it.key()))
+                    continue;                       // already covered by sysfs
+                double pct = 0.0;
+                if (fdInfoElapsedNs > 0 && g.prevFdInfoEngineNs.contains(it.key()))
+                {
+                    const qint64 delta = it.value() - g.prevFdInfoEngineNs.value(it.key());
+                    pct = static_cast<double>(delta) / static_cast<double>(fdInfoElapsedNs) * 100.0;
+                }
+                QString label = it.key();
+                for (int ci = 0; ci < label.size(); ++ci)
+                {
+                    if (ci == 0 || (ci > 0 && label[ci - 1] == QChar('-')))
+                        label[ci] = label[ci].toUpper();
+                }
+                addEngine(it.key(), label, pct);
+            }
+            g.prevFdInfoEngineNs = curNs;
+        }
+
+        g.engines = engines;
     }
 
+    // Restart the fdinfo timer after all DRM cards are sampled.
+    this->m_gpuFdInfoTimer.start();
+    this->m_gpuFdInfoTimerStarted = true;
+
     return !this->m_drmCards.isEmpty();
+}
+
+// ── GPU: fdinfo engine scanner ────────────────────────────────────────────────
+// Reads drm-engine-* nanosecond values from /proc fdinfo files.
+// Caches discovered fdinfo paths and only does a full /proc rescan every few ticks.
+// De-duplicates by drm-client-id.
+
+QHash<QString, qint64> PerfDataProvider::scanDrmFdInfoEngines(DrmCard &card)
+{
+    QHash<QString, qint64> totals;
+    QSet<int> seenClients;
+
+    // Helper: parse a single fdinfo file and accumulate engine nanosecond values.
+    auto parseFdInfo = [&](const QString &infoPath) -> bool
+    {
+        const QString content = readSysTextFile(infoPath);
+        if (content.isEmpty())
+            return false;
+
+        if (!content.contains(QLatin1String("drm-pdev:\t") + card.id)
+            && !content.contains(QLatin1String("drm-pdev: ") + card.id))
+            return false;
+
+        int clientId = -1;
+        for (const auto &line : QStringView(content).split('\n'))
+        {
+            if (line.startsWith(QLatin1String("drm-client-id:")))
+            {
+                clientId = line.mid(line.indexOf(':') + 1).trimmed().toInt();
+                break;
+            }
+        }
+        if (clientId >= 0 && seenClients.contains(clientId))
+            return false;
+        if (clientId >= 0)
+            seenClients.insert(clientId);
+
+        bool found = false;
+        for (const auto &line : QStringView(content).split('\n'))
+        {
+            if (!line.startsWith(QLatin1String("drm-engine-")))
+                continue;
+            const int colonPos = line.indexOf(':');
+            if (colonPos < 0)
+                continue;
+            const QString key = line.mid(11, colonPos - 11).toString();
+            const QStringView valStr = line.mid(colonPos + 1).trimmed();
+            const int spacePos = valStr.indexOf(' ');
+            const qint64 ns = (spacePos > 0 ? valStr.left(spacePos) : valStr)
+                                  .toLongLong();
+            totals[key] += ns;
+            found = true;
+        }
+        return found;
+    };
+
+    const bool fullRescan = (this->m_gpuFdInfoRescanCounter % 5 == 1)
+                            || card.cachedFdInfoPaths.isEmpty();
+
+    if (!fullRescan)
+    {
+        // Fast path: only re-read previously discovered fdinfo paths.
+        QStringList stillValid;
+        for (const QString &path : std::as_const(card.cachedFdInfoPaths))
+        {
+            if (parseFdInfo(path))
+                stillValid.append(path);
+        }
+        card.cachedFdInfoPaths = stillValid;
+        return totals;
+    }
+
+    // Full rescan: walk /proc/*/fd to discover new fdinfo paths.
+    QStringList newCache;
+
+    const QDir procDir(QStringLiteral("/proc"));
+    const QStringList pids = procDir.entryList(QDir::Dirs | QDir::NoDotAndDotDot);
+
+    for (const QString &pidEntry : pids)
+    {
+        bool ok = false;
+        pidEntry.toInt(&ok);
+        if (!ok)
+            continue;
+
+        const QString fdDirPath = QStringLiteral("/proc/") + pidEntry + QStringLiteral("/fd");
+        const QDir fdDir(fdDirPath);
+        if (!fdDir.exists())
+            continue;
+
+        const QStringList fdEntries = fdDir.entryList(QDir::NoDotAndDotDot);
+        for (const QString &fdNum : fdEntries)
+        {
+            const QString linkPath = fdDirPath + QChar('/') + fdNum;
+            char buf[PATH_MAX];
+            const ssize_t len = ::readlink(linkPath.toLocal8Bit().constData(),
+                                           buf, sizeof(buf) - 1);
+            if (len <= 0)
+                continue;
+            buf[len] = '\0';
+            const QByteArray target(buf, static_cast<int>(len));
+
+            if (target != card.renderNodePath.toLatin1()
+                && target != card.cardNodePath.toLatin1())
+                continue;
+
+            const QString infoPath = QStringLiteral("/proc/") + pidEntry
+                                     + QStringLiteral("/fdinfo/") + fdNum;
+            if (parseFdInfo(infoPath))
+                newCache.append(infoPath);
+        }
+    }
+
+    card.cachedFdInfoPaths = newCache;
+    return totals;
 }
 
 double PerfDataProvider::parsePercentField(const QString &field)

--- a/src/perf/perfdataprovider.h
+++ b/src/perf/perfdataprovider.h
@@ -149,6 +149,9 @@ namespace Perf
             const QVector<double> &GpuMemUsageHistory(int i) const;
             const QVector<double> &GpuCopyTxHistory(int i) const;
             const QVector<double> &GpuCopyRxHistory(int i) const;
+            qint64 GpuSharedMemUsedMiB(int i) const;
+            qint64 GpuSharedMemTotalMiB(int i) const;
+            const QVector<double> &GpuSharedMemHistory(int i) const;
             int GpuEngineCount(int gpuIndex) const;
             QString GpuEngineName(int gpuIndex, int engineIndex) const;
             double GpuEnginePercent(int gpuIndex, int engineIndex) const;
@@ -209,13 +212,17 @@ namespace Perf
                 int             temperatureC { -1 };
                 qint64          memUsedMiB { 0 };
                 qint64          memTotalMiB { 0 };
+                qint64          sharedMemUsedMiB { 0 };
+                qint64          sharedMemTotalMiB { 0 };
                 double          copyTxBps { 0.0 };
                 double          copyRxBps { 0.0 };
                 QVector<double> utilHistory;
                 QVector<double> memUsageHistory;
+                QVector<double> sharedMemHistory;
                 QVector<double> copyTxHistory;
                 QVector<double> copyRxHistory;
                 QVector<GpuEngineSample> engines;
+                QHash<QString, qint64> prevFdInfoEngineNs;
             };
 
             // Cached sysfs paths for a kernel DRM-managed GPU.
@@ -229,7 +236,17 @@ namespace Perf
                 QString   busyPath;       // .../gpu_busy_percent
                 QString   vramTotalPath;  // .../mem_info_vram_total
                 QString   vramUsedPath;   // .../mem_info_vram_used
+                QString   gttTotalPath;   // .../mem_info_gtt_total  (shared / system)
+                QString   gttUsedPath;    // .../mem_info_gtt_used
                 QString   tempPath;       // hwmon temp1_input (milli-°C)
+                QString   renderNodePath; // /dev/dri/renderDN  (for fdinfo matching)
+                QString   cardNodePath;   // /dev/dri/cardN
+
+                // All *_busy_percent engine files (excluding gpu_busy_percent).
+                QVector<QPair<QString, QString>>  engineBusyPaths; // (key, sysfs path)
+
+                // Cached fdinfo paths from the last full /proc scan.
+                QStringList     cachedFdInfoPaths;
             };
 
             struct NetworkSample
@@ -325,6 +342,9 @@ namespace Perf
             bool                m_hasNvml { false };
             void               *m_nvmlLibHandle { nullptr };
             QVector<DrmCard>    m_drmCards;
+            QElapsedTimer       m_gpuFdInfoTimer;
+            bool                m_gpuFdInfoTimerStarted { false };
+            int                 m_gpuFdInfoRescanCounter { 0 };
 
             /// Sample /proc/stat aggregate + per-core jiffies and append utilization histories.
             bool sampleCpu();
@@ -348,6 +368,7 @@ namespace Perf
             void detectDrmCards();
             bool sampleNvml();
             bool sampleDrm();
+            QHash<QString, qint64> scanDrmFdInfoEngines(DrmCard &card);
             void unloadGpuBackends();
             static double parsePercentField(const QString &field);
             static qint64 parseMiBField(const QString &field);


### PR DESCRIPTION
Rewrite GPU backend to detect multiple cards and add AMD monitoring via drm sysfs/fdinfo.
Detect and sample multiple GPUs, skip Nvidia DRM when NVML is active, when AMD GPU detected, read utilization, VRAM, GTT (shared memory), temperature from sysfs.
A Better Nvidia CUDA useage caculator instead of showing the same overall GPU for both.
