### PR TITLE
failing to build (Nix): update icon path

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -32,7 +32,7 @@
               categories = [ "System" "Monitor" ];
               terminal = false;
             };
-            icon = ./res/tux_manager_icon.svg;
+            icon = ./src/tux_manager_icon.svg;
           in
           pkgs.stdenv.mkDerivation {
             pname = "tux-manager";


### PR DESCRIPTION
`flake.nix` was left out from 42181f6