### PR TITLE
Show all IPv6 addresses in NIC details

### DIFF
--- a/src/perf/networkdetailwidget.cpp
+++ b/src/perf/networkdetailwidget.cpp
@@ -128,7 +128,7 @@ void NetworkDetailWidget::SetNetwork(int index)
         this->ui->typeValueLabel->setText(network.Type);
         this->ui->speedValueLabel->setText(network.LinkSpeedMbps > 0 ? QString::number(network.LinkSpeedMbps) + tr(" Mbps") : tr("Unknown"));
         this->ui->ipv4ValueLabel->setText(network.IPv4.isEmpty() ? tr("—") : network.IPv4);
-        this->ui->ipv6ValueLabel->setText(network.IPv6Addresses.isEmpty() ? tr("—") : network.IPv6Addresses.join('\n'));
+        this->ui->ipv6ValueLabel->setText(network.IPv6.isEmpty() ? tr("—") : network.IPv6.join('\n'));
 
         this->ui->throughputGraphWidget->SetDataSource(network.RxHistory, 1024.0);
         this->ui->throughputGraphWidget->SetOverlayDataSource(network.TxHistory);

--- a/src/perf/networkdetailwidget.cpp
+++ b/src/perf/networkdetailwidget.cpp
@@ -128,7 +128,7 @@ void NetworkDetailWidget::SetNetwork(int index)
         this->ui->typeValueLabel->setText(network.Type);
         this->ui->speedValueLabel->setText(network.LinkSpeedMbps > 0 ? QString::number(network.LinkSpeedMbps) + tr(" Mbps") : tr("Unknown"));
         this->ui->ipv4ValueLabel->setText(network.IPv4.isEmpty() ? tr("—") : network.IPv4);
-        this->ui->ipv6ValueLabel->setText(network.IPv6.isEmpty() ? tr("—") : network.IPv6);
+        this->ui->ipv6ValueLabel->setText(network.IPv6Addresses.isEmpty() ? tr("—") : network.IPv6Addresses.join('\n'));
 
         this->ui->throughputGraphWidget->SetDataSource(network.RxHistory, 1024.0);
         this->ui->throughputGraphWidget->SetOverlayDataSource(network.TxHistory);

--- a/src/perf/networkdetailwidget.ui
+++ b/src/perf/networkdetailwidget.ui
@@ -240,17 +240,29 @@
       </widget>
      </item>
      <item row="4" column="2">
-      <widget class="QLabel" name="ipv6Label">
+     <widget class="QLabel" name="ipv6Label">
        <property name="styleSheet">
         <string></string>
        </property>
+       <property name="alignment">
+        <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
+       </property>
        <property name="text">
-        <string>IPv6 address</string>
+        <string>IPv6 addresses</string>
        </property>
       </widget>
      </item>
      <item row="4" column="3">
       <widget class="QLabel" name="ipv6ValueLabel">
+       <property name="textFormat">
+        <enum>Qt::TextFormat::PlainText</enum>
+       </property>
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
+       </property>
        <property name="text">
         <string>—</string>
        </property>

--- a/src/system/network.cpp
+++ b/src/system/network.cpp
@@ -102,7 +102,7 @@ void Network::refreshNetworkMetadata(bool force)
     struct IfAddrInfo
     {
         QString ipv4;
-        QStringList ipv6Addresses;
+        QStringList ipv6;
     };
     QHash<QString, IfAddrInfo> ifaddrByName;
     struct ifaddrs *ifaddr = nullptr;
@@ -136,8 +136,8 @@ void Network::refreshNetworkMetadata(bool force)
             else if (fam == AF_INET6)
             {
                 const QString ipv6 = QString::fromLatin1(host);
-                if (!info.ipv6Addresses.contains(ipv6))
-                    info.ipv6Addresses.append(ipv6);
+                if (!info.ipv6.contains(ipv6))
+                    info.ipv6.append(ipv6);
             }
         }
         ::freeifaddrs(ifaddr);
@@ -149,7 +149,7 @@ void Network::refreshNetworkMetadata(bool force)
         n->Type = networkTypeFromArpType(arpType);
         n->LinkSpeedMbps = readLinkSpeedMbps(n->Name);
         n->IPv4 = ifaddrByName.value(n->Name).ipv4;
-        n->IPv6Addresses = ifaddrByName.value(n->Name).ipv6Addresses;
+        n->IPv6 = ifaddrByName.value(n->Name).ipv6;
     }
 }
 

--- a/src/system/network.cpp
+++ b/src/system/network.cpp
@@ -102,7 +102,7 @@ void Network::refreshNetworkMetadata(bool force)
     struct IfAddrInfo
     {
         QString ipv4;
-        QString ipv6;
+        QStringList ipv6Addresses;
     };
     QHash<QString, IfAddrInfo> ifaddrByName;
     struct ifaddrs *ifaddr = nullptr;
@@ -133,8 +133,12 @@ void Network::refreshNetworkMetadata(bool force)
             IfAddrInfo &info = ifaddrByName[name];
             if (fam == AF_INET && info.ipv4.isEmpty())
                 info.ipv4 = QString::fromLatin1(host);
-            else if (fam == AF_INET6 && info.ipv6.isEmpty())
-                info.ipv6 = QString::fromLatin1(host);
+            else if (fam == AF_INET6)
+            {
+                const QString ipv6 = QString::fromLatin1(host);
+                if (!info.ipv6Addresses.contains(ipv6))
+                    info.ipv6Addresses.append(ipv6);
+            }
         }
         ::freeifaddrs(ifaddr);
     }
@@ -145,7 +149,7 @@ void Network::refreshNetworkMetadata(bool force)
         n->Type = networkTypeFromArpType(arpType);
         n->LinkSpeedMbps = readLinkSpeedMbps(n->Name);
         n->IPv4 = ifaddrByName.value(n->Name).ipv4;
-        n->IPv6 = ifaddrByName.value(n->Name).ipv6;
+        n->IPv6Addresses = ifaddrByName.value(n->Name).ipv6Addresses;
     }
 }
 

--- a/src/system/network.h
+++ b/src/system/network.h
@@ -35,7 +35,7 @@ class Network
             QString         Name;      ///< Interface name, e.g. enp5s0
             QString         Type;      ///< Ethernet/Wi-Fi/Other
             QString         IPv4;
-            QStringList     IPv6Addresses;
+            QStringList     IPv6;
             bool            IsActive { true };
             int             LinkSpeedMbps { 0 };
             quint64         PrevRxBytes { 0 };

--- a/src/system/network.h
+++ b/src/system/network.h
@@ -23,6 +23,7 @@
 #include "../historybuffer.h"
 #include <memory>
 #include <QElapsedTimer>
+#include <QStringList>
 #include <QVector>
 #include <vector>
 
@@ -34,7 +35,7 @@ class Network
             QString         Name;      ///< Interface name, e.g. enp5s0
             QString         Type;      ///< Ethernet/Wi-Fi/Other
             QString         IPv4;
-            QString         IPv6;
+            QStringList     IPv6Addresses;
             bool            IsActive { true };
             int             LinkSpeedMbps { 0 };
             quint64         PrevRxBytes { 0 };


### PR DESCRIPTION
IPv6, unlike IPv4, allows multiple addresses (e.g., link-local, GUA, ULA) to be assigned to a single interface.

Previously, the NIC tab displayed only one IPv6 address.
This has been updated to display all IPv6 addresses.
