### PR TITLE
Nix/fix: spawn a terminal on nixos

### DIFF
--- a/src/processeswidget.cpp
+++ b/src/processeswidget.cpp
@@ -1189,10 +1189,13 @@ QString ProcessesWidget::findTerminalExecutable()
         "xterm"
     };
     static const QStringList trustedPrefixes {
+        // FHS:
         "/usr/bin/",
         "/bin/",
         "/sbin/",
-        "/usr/sbin/"
+        "/usr/sbin/",
+        // NixOS/Home-manager:
+        "/nix/store/"
     };
 
     for (const QString &candidate : terminalCandidates)


### PR DESCRIPTION
Allows tux manager to start a terminal by adding `/nix/store` to `trustedPrefixes` 