### PR TITLE
Make `refresh interval` and `graph time` context menu options available on the graphs

### DIFF
--- a/src/perf/cpudetailwidget.cpp
+++ b/src/perf/cpudetailwidget.cpp
@@ -236,7 +236,8 @@ void CpuDetailWidget::onContextMenuRequested(const QPoint &globalPos)
     menu.addSeparator();
 
     // ── Copy ─────────────────────────────────────────────────────────────────
-    UIHelper::AddCopyWidgetAction(&menu, this->m_graphArea, tr("Copy graph"));
+    // UIHelper::AddCopyWidgetAction(&menu, this->m_graphArea, tr("Copy graph"));
+    UIHelper::AddGraphContextMenuItems(&menu, this->m_graphArea);
 
     menu.exec(globalPos);
 }

--- a/src/perf/cpudetailwidget.cpp
+++ b/src/perf/cpudetailwidget.cpp
@@ -236,7 +236,6 @@ void CpuDetailWidget::onContextMenuRequested(const QPoint &globalPos)
     menu.addSeparator();
 
     // ── Copy ─────────────────────────────────────────────────────────────────
-    // UIHelper::AddCopyWidgetAction(&menu, this->m_graphArea, tr("Copy graph"));
     UIHelper::AddGraphContextMenuItems(&menu, this->m_graphArea);
 
     menu.exec(globalPos);

--- a/src/perf/diskdetailwidget.cpp
+++ b/src/perf/diskdetailwidget.cpp
@@ -76,8 +76,8 @@ DiskDetailWidget::DiskDetailWidget(QWidget *parent) : QWidget(parent), ui(new Ui
     this->ui->transferGraphWidget->SetGridRows(4);
     this->ui->transferGraphWidget->SetSeriesNames(tr("Read"), tr("Write"));
     this->ui->transferGraphWidget->SetValueFormat(GraphWidget::ValueFormat::BytesPerSec);
-    UIHelper::EnableCopyWidgetContextMenu(this->ui->activeGraphWidget);
-    UIHelper::EnableCopyWidgetContextMenu(this->ui->transferGraphWidget);
+    UIHelper::EnableGraphContextMenu(this->ui->activeGraphWidget);
+    UIHelper::EnableGraphContextMenu(this->ui->transferGraphWidget);
     this->ui->activeGraphMaxLabel->setText(tr("100%"));
     UIHelper::EnableCopyLabelContextMenu(this->ui->activeValueLabel);
     UIHelper::EnableCopyLabelContextMenu(this->ui->capacityValueLabel);

--- a/src/perf/gpudetailwidget.cpp
+++ b/src/perf/gpudetailwidget.cpp
@@ -78,7 +78,7 @@ GpuDetailWidget::GpuDetailWidget(QWidget *parent) : QWidget(parent), ui(new Ui::
         auto *graph = new GraphWidget(this);
         configureGraph(graph);
         graph->setMinimumHeight(120);
-        UIHelper::EnableCopyWidgetContextMenu(graph);
+        UIHelper::EnableGraphContextMenu(graph);
 
         this->m_engineSelectors.append(selector);
         this->m_engineValueLabels.append(value);
@@ -103,17 +103,17 @@ GpuDetailWidget::GpuDetailWidget(QWidget *parent) : QWidget(parent), ui(new Ui::
 
     configureGraph(this->ui->dedicatedMemGraphWidget);
     this->ui->dedicatedMemGraphWidget->SetSeriesNames(tr("Dedicated memory usage"));
-    UIHelper::EnableCopyWidgetContextMenu(this->ui->dedicatedMemGraphWidget);
+    UIHelper::EnableGraphContextMenu(this->ui->dedicatedMemGraphWidget);
 
     configureGraph(this->ui->sharedMemGraphWidget);
     this->ui->sharedMemGraphWidget->SetSeriesNames(tr("Shared memory usage"));
-    UIHelper::EnableCopyWidgetContextMenu(this->ui->sharedMemGraphWidget);
+    UIHelper::EnableGraphContextMenu(this->ui->sharedMemGraphWidget);
 
     configureGraph(this->ui->copyBwGraphWidget);
     this->ui->copyBwGraphWidget->SetSeriesNames(tr("TX"), tr("RX"));
     this->ui->copyBwGraphWidget->SetValueFormat(GraphWidget::ValueFormat::BytesPerSec);
     this->ui->copyBwGraphWidget->setToolTip(tr("Copy bandwidth: light trace = TX, dark trace = RX"));
-    UIHelper::EnableCopyWidgetContextMenu(this->ui->copyBwGraphWidget);
+    UIHelper::EnableGraphContextMenu(this->ui->copyBwGraphWidget);
 
     UIHelper::EnableCopyLabelContextMenu(this->ui->utilValueLabel);
     UIHelper::EnableCopyLabelContextMenu(this->ui->tempValueLabel);

--- a/src/perf/memorydetailwidget.cpp
+++ b/src/perf/memorydetailwidget.cpp
@@ -73,7 +73,7 @@ MemoryDetailWidget::MemoryDetailWidget(QWidget *parent) : QWidget(parent), ui(ne
     this->ui->graphWidget->SetGridRows(4);
     this->ui->graphWidget->SetSeriesNames(tr("Used memory"));
     this->ui->graphWidget->SetValueFormat(GraphWidget::ValueFormat::Percent);
-    UIHelper::EnableCopyWidgetContextMenu(this->ui->graphWidget);
+    UIHelper::EnableGraphContextMenu(this->ui->graphWidget);
     UIHelper::EnableCopyLabelContextMenu(this->ui->statInUseValue);
     UIHelper::EnableCopyLabelContextMenu(this->ui->statAvailValue);
     UIHelper::EnableCopyLabelContextMenu(this->ui->statCompressedValue);

--- a/src/perf/networkdetailwidget.cpp
+++ b/src/perf/networkdetailwidget.cpp
@@ -176,7 +176,7 @@ void NetworkDetailWidget::onGraphContextMenuRequested(const QPoint &pos)
     connect(bytesAction, &QAction::triggered, this, &NetworkDetailWidget::onShowBytesTriggered);
 
     menu.addSeparator();
-    UIHelper::AddCopyWidgetAction(&menu, this->ui->throughputGraphWidget, tr("Copy graph"));
+    UIHelper::AddGraphContextMenuItems(&menu, this->ui->throughputGraphWidget);
 
     menu.exec(this->ui->throughputGraphWidget->mapToGlobal(pos));
 }

--- a/src/perf/swapdetailwidget.cpp
+++ b/src/perf/swapdetailwidget.cpp
@@ -89,7 +89,7 @@ SwapDetailWidget::SwapDetailWidget(QWidget *parent) : QWidget(parent), ui(new Ui
     this->ui->activityGraphWidget->setToolTip(
                 tr("Swap in: disk -> RAM (pages read back into memory)\n"
                    "Swap out: RAM -> disk (pages written to swap storage)"));
-    UIHelper::EnableCopyWidgetContextMenu(this->ui->activityGraphWidget);
+    UIHelper::EnableGraphContextMenu(this->ui->activityGraphWidget);
 
     UIHelper::EnableCopyLabelContextMenu(this->ui->usageValueLabel);
     UIHelper::EnableCopyLabelContextMenu(this->ui->inUseValueLabel);
@@ -221,7 +221,7 @@ void SwapDetailWidget::onContextMenuRequested(const QPoint &globalPos)
 
     menu.addSeparator();
 
-    UIHelper::AddCopyWidgetAction(&menu, this->ui->usageGraphArea, tr("Copy graph"));
+    UIHelper::AddGraphContextMenuItems(&menu, this->ui->usageGraphArea);
 
     menu.exec(globalPos);
 }

--- a/src/performancewidget.cpp
+++ b/src/performancewidget.cpp
@@ -378,8 +378,6 @@ void PerformanceWidget::onSidePanelContextMenu(Perf::SidePanelItem * /*item*/, c
 {
     QMenu menu(this);
     QHash<QAction *, int> graphWindowActions;
-    QHash<QAction *, int> refreshIntervalActions;
-    QAction *pausedRefreshAction = nullptr;
 
     QAction *cpu = menu.addAction(tr("CPU"));
     cpu->setCheckable(true);
@@ -427,8 +425,10 @@ void PerformanceWidget::onSidePanelContextMenu(Perf::SidePanelItem * /*item*/, c
         graphWindowActions.insert(a, sec);
     }
 
-    QMenu *refreshMenu = menu.addMenu(tr("Refresh interval"));
-    UIHelper::PopulateRefreshIntervalMenu(refreshMenu, refreshIntervalActions, pausedRefreshAction);
+    menu.addSeparator();
+    UIHelper::AddRefreshIntervalContextMenu(&menu);
+
+    menu.addSeparator();
     UIHelper::AddGlobalContextMenuItems(&menu, this);
 
     QAction *picked = menu.exec(globalPos);
@@ -444,9 +444,6 @@ void PerformanceWidget::onSidePanelContextMenu(Perf::SidePanelItem * /*item*/, c
             this->onProviderUpdated();
         return;
     }
-
-    if (UIHelper::ApplyRefreshIntervalAction(picked, refreshIntervalActions, pausedRefreshAction))
-        return;
 
     if (picked == customizeOrder)
     {

--- a/src/performancewidget.cpp
+++ b/src/performancewidget.cpp
@@ -416,7 +416,7 @@ void PerformanceWidget::onSidePanelContextMenu(Perf::SidePanelItem * /*item*/, c
     showGrid->setChecked(CFG->SidePanelGridEnabled);
 
     menu.addSeparator();
-    UIHelper::AddRefreshIntervalContextMenu(&menu);
+    UIHelper::AddRefreshIntervalContextMenu(&menu, nullptr, this->m_active);
 
     menu.addSeparator();
     UIHelper::AddGlobalContextMenuItems(&menu, this);

--- a/src/performancewidget.cpp
+++ b/src/performancewidget.cpp
@@ -417,6 +417,7 @@ void PerformanceWidget::onSidePanelContextMenu(Perf::SidePanelItem * /*item*/, c
 
     menu.addSeparator();
     UIHelper::AddRefreshIntervalContextMenu(&menu, nullptr, this->m_active);
+    UIHelper::AddGraphWindowContextMenu(&menu);
 
     menu.addSeparator();
     UIHelper::AddGlobalContextMenuItems(&menu, this);

--- a/src/performancewidget.cpp
+++ b/src/performancewidget.cpp
@@ -74,8 +74,12 @@ namespace
 // Construction
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
+PerformanceWidget *PerformanceWidget::s_instance = nullptr;
+
 PerformanceWidget::PerformanceWidget(QWidget *parent) : QWidget(parent), ui(new Ui::PerformanceWidget)
 {
+    s_instance = this;
+
     // Ensure the metrics are initialized before we start enumerating devices
     Metrics::Get();
 
@@ -122,6 +126,7 @@ PerformanceWidget::PerformanceWidget(QWidget *parent) : QWidget(parent), ui(new 
 
 PerformanceWidget::~PerformanceWidget()
 {
+    s_instance = nullptr;
     delete this->ui;
 }
 
@@ -377,7 +382,6 @@ void PerformanceWidget::SetActive(bool active)
 void PerformanceWidget::onSidePanelContextMenu(Perf::SidePanelItem * /*item*/, const QPoint &globalPos)
 {
     QMenu menu(this);
-    QHash<QAction *, int> graphWindowActions;
 
     QAction *cpu = menu.addAction(tr("CPU"));
     cpu->setCheckable(true);
@@ -412,20 +416,6 @@ void PerformanceWidget::onSidePanelContextMenu(Perf::SidePanelItem * /*item*/, c
     showGrid->setChecked(CFG->SidePanelGridEnabled);
 
     menu.addSeparator();
-    QMenu *timeMenu = menu.addMenu(tr("Graph time"));
-    QVector<int> intervals = CFG->DataWindowAvailableIntervals;
-    if (intervals.isEmpty())
-        intervals.append(CFG->PerfGraphWindowSec);
-
-    for (int sec : intervals)
-    {
-        QAction *a = timeMenu->addAction(Misc::SimplifyTime(sec));
-        a->setCheckable(true);
-        a->setChecked(CFG->PerfGraphWindowSec == sec);
-        graphWindowActions.insert(a, sec);
-    }
-
-    menu.addSeparator();
     UIHelper::AddRefreshIntervalContextMenu(&menu);
 
     menu.addSeparator();
@@ -434,16 +424,6 @@ void PerformanceWidget::onSidePanelContextMenu(Perf::SidePanelItem * /*item*/, c
     QAction *picked = menu.exec(globalPos);
     if (!picked)
         return;
-
-    if (graphWindowActions.contains(picked))
-    {
-        const int requestedWindow = graphWindowActions.value(picked);
-        CFG->PerfGraphWindowSec = requestedWindow;
-        this->applyGraphWindowSeconds();
-        if (this->m_active)
-            this->onProviderUpdated();
-        return;
-    }
 
     if (picked == customizeOrder)
     {

--- a/src/performancewidget.h
+++ b/src/performancewidget.h
@@ -40,6 +40,8 @@ QT_END_NAMESPACE
 class PerformanceWidget : public QWidget
 {
     Q_OBJECT
+    
+    static PerformanceWidget *s_instance;
 
     public:
         explicit PerformanceWidget(QWidget *parent = nullptr);
@@ -47,9 +49,11 @@ class PerformanceWidget : public QWidget
         void SetActive(bool active);
         bool IsActive() const { return this->m_active; }
         void ApplyColorScheme();
-
-    private slots:
+        static PerformanceWidget *Get() { return s_instance; };
         void onProviderUpdated();
+        void applyGraphWindowSeconds();
+        
+    private slots:
         void onSidePanelContextMenu(Perf::SidePanelItem *item, const QPoint &globalPos);
 
     private:
@@ -81,7 +85,6 @@ class PerformanceWidget : public QWidget
         void setupGpuPanels();
         void applySidePanelOrder();
         void tagTimeAxisLabels();
-        void applyGraphWindowSeconds();
         void applyPanelVisibility();
         void applySidePanelGridEnabled();
         void updateSamplingPolicy();

--- a/src/performancewidget.h
+++ b/src/performancewidget.h
@@ -41,8 +41,6 @@ class PerformanceWidget : public QWidget
 {
     Q_OBJECT
     
-    static PerformanceWidget *s_instance;
-
     public:
         explicit PerformanceWidget(QWidget *parent = nullptr);
         ~PerformanceWidget();
@@ -57,6 +55,8 @@ class PerformanceWidget : public QWidget
         void onSidePanelContextMenu(Perf::SidePanelItem *item, const QPoint &globalPos);
 
     private:
+        static PerformanceWidget *s_instance;
+        
         Ui::PerformanceWidget      *ui;
         Perf::SidePanel            *m_sidePanel;
         QStackedWidget             *m_stack;

--- a/src/processeswidget.cpp
+++ b/src/processeswidget.cpp
@@ -565,8 +565,6 @@ void ProcessesWidget::onTableContextMenu(const QPoint &pos)
 {
     // Pause refresh during context menu so we don't loose the selection
     this->m_tableContextMenuOpen = true;
-    QHash<QAction *, int> refreshIntervalActions;
-    QAction *pausedRefreshAction = nullptr;
 
     const QModelIndex clickedIndex = this->ui->tableView->indexAt(pos);
     const QModelIndex targetIndex = clickedIndex.isValid() ? clickedIndex : this->ui->tableView->currentIndex();
@@ -681,12 +679,10 @@ void ProcessesWidget::onTableContextMenu(const QPoint &pos)
     connect(reniceAction, &QAction::triggered, this, &ProcessesWidget::reniceSelected);
 
     menu.addSeparator();
-    QMenu *refreshMenu = menu.addMenu(tr("Refresh interval"));
-    UIHelper::PopulateRefreshIntervalMenu(refreshMenu, refreshIntervalActions, pausedRefreshAction);
+    UIHelper::AddRefreshIntervalContextMenu(&menu);
     UIHelper::AddGlobalContextMenuItems(&menu, this);
 
-    QAction *picked = menu.exec(this->ui->tableView->viewport()->mapToGlobal(pos));
-    UIHelper::ApplyRefreshIntervalAction(picked, refreshIntervalActions, pausedRefreshAction, this->m_refreshTimer, this->m_active);
+    menu.exec(this->ui->tableView->viewport()->mapToGlobal(pos));
 
     this->m_contextMenuTargetIndex = QModelIndex();
     this->m_tableContextMenuOpen = false;
@@ -698,8 +694,6 @@ void ProcessesWidget::onTreeContextMenu(const QPoint &pos)
 {
     this->m_tableContextMenuOpen = true;
     QMenu menu(this);
-    QHash<QAction *, int> refreshIntervalActions;
-    QAction *pausedRefreshAction = nullptr;
 
     QMenu *viewMenu = menu.addMenu(tr("View"));
     QAction *kernelAct = viewMenu->addAction(tr("Kernel tasks"));
@@ -740,12 +734,10 @@ void ProcessesWidget::onTreeContextMenu(const QPoint &pos)
     connect(reniceAction, &QAction::triggered, this, &ProcessesWidget::reniceSelected);
 
     menu.addSeparator();
-    QMenu *refreshMenu = menu.addMenu(tr("Refresh interval"));
-    UIHelper::PopulateRefreshIntervalMenu(refreshMenu, refreshIntervalActions, pausedRefreshAction);
+    UIHelper::AddRefreshIntervalContextMenu(&menu);
     UIHelper::AddGlobalContextMenuItems(&menu, this);
 
-    QAction *picked = menu.exec(this->m_treeView->viewport()->mapToGlobal(pos));
-    UIHelper::ApplyRefreshIntervalAction(picked, refreshIntervalActions, pausedRefreshAction, this->m_refreshTimer, this->m_active);
+    menu.exec(this->m_treeView->viewport()->mapToGlobal(pos));
 
     this->m_tableContextMenuOpen = false;
     if (this->m_active && this->m_refreshPending && !CFG->RefreshPaused)

--- a/src/processeswidget.cpp
+++ b/src/processeswidget.cpp
@@ -679,7 +679,7 @@ void ProcessesWidget::onTableContextMenu(const QPoint &pos)
     connect(reniceAction, &QAction::triggered, this, &ProcessesWidget::reniceSelected);
 
     menu.addSeparator();
-    UIHelper::AddRefreshIntervalContextMenu(&menu);
+    UIHelper::AddRefreshIntervalContextMenu(&menu, this->m_refreshTimer, this->m_active);
     UIHelper::AddGlobalContextMenuItems(&menu, this);
 
     menu.exec(this->ui->tableView->viewport()->mapToGlobal(pos));
@@ -734,7 +734,7 @@ void ProcessesWidget::onTreeContextMenu(const QPoint &pos)
     connect(reniceAction, &QAction::triggered, this, &ProcessesWidget::reniceSelected);
 
     menu.addSeparator();
-    UIHelper::AddRefreshIntervalContextMenu(&menu);
+    UIHelper::AddRefreshIntervalContextMenu(&menu, this->m_refreshTimer, this->m_active);
     UIHelper::AddGlobalContextMenuItems(&menu, this);
 
     menu.exec(this->m_treeView->viewport()->mapToGlobal(pos));

--- a/src/serviceswidget.cpp
+++ b/src/serviceswidget.cpp
@@ -232,8 +232,6 @@ void ServicesWidget::onHeaderContextMenu(const QPoint &pos)
 void ServicesWidget::onTableContextMenu(const QPoint &pos)
 {
     this->m_tableContextMenuOpen = true;
-    QHash<QAction *, int> refreshIntervalActions;
-    QAction *pausedRefreshAction = nullptr;
 
     const QModelIndex clickedIndex = this->ui->tableView->indexAt(pos);
     const QModelIndex targetIndex = clickedIndex.isValid() ? clickedIndex : this->ui->tableView->currentIndex();
@@ -320,12 +318,10 @@ void ServicesWidget::onTableContextMenu(const QPoint &pos)
     });
 
     menu.addSeparator();
-    QMenu *refreshMenu = menu.addMenu(tr("Refresh interval"));
-    UIHelper::PopulateRefreshIntervalMenu(refreshMenu, refreshIntervalActions, pausedRefreshAction);
+    UIHelper::AddRefreshIntervalContextMenu(&menu);
     UIHelper::AddGlobalContextMenuItems(&menu, this);
 
-    QAction *picked = menu.exec(this->ui->tableView->viewport()->mapToGlobal(pos));
-    UIHelper::ApplyRefreshIntervalAction(picked, refreshIntervalActions, pausedRefreshAction, this->m_refreshTimer, this->m_active);
+    menu.exec(this->ui->tableView->viewport()->mapToGlobal(pos));
 
     this->m_tableContextMenuOpen = false;
 }

--- a/src/serviceswidget.cpp
+++ b/src/serviceswidget.cpp
@@ -318,7 +318,7 @@ void ServicesWidget::onTableContextMenu(const QPoint &pos)
     });
 
     menu.addSeparator();
-    UIHelper::AddRefreshIntervalContextMenu(&menu);
+    UIHelper::AddRefreshIntervalContextMenu(&menu, this->m_refreshTimer, this->m_active);
     UIHelper::AddGlobalContextMenuItems(&menu, this);
 
     menu.exec(this->ui->tableView->viewport()->mapToGlobal(pos));

--- a/src/ui/uihelper.cpp
+++ b/src/ui/uihelper.cpp
@@ -21,6 +21,7 @@
 #include "../configuration.h"
 #include "../metrics.h"
 #include "../misc.h"
+#include "../performancewidget.h"
 
 #include <QAbstractItemModel>
 #include <QAction>
@@ -264,12 +265,42 @@ void UIHelper::AddRefreshIntervalContextMenu(QMenu *menu)
     });
 }
 
+void UIHelper::AddGraphWindowContextMenu(QMenu *menu)
+{
+    QMenu *timeMenu = menu->addMenu(QObject::tr("Graph time"));
+    QVector<int> intervals = CFG->DataWindowAvailableIntervals;
+    if (intervals.isEmpty())
+        intervals.append(CFG->PerfGraphWindowSec);
+    QHash<QAction *, int> graphWindowActions;
+
+    for (int sec : intervals)
+    {
+        QAction *a = timeMenu->addAction(Misc::SimplifyTime(sec));
+        a->setCheckable(true);
+        a->setChecked(CFG->PerfGraphWindowSec == sec);
+        graphWindowActions.insert(a, sec);
+
+        QObject::connect(a, &QAction::triggered, menu, [=]()
+        {          
+            const int requestedWindow = graphWindowActions.value(a);
+            CFG->PerfGraphWindowSec = requestedWindow;
+            PerformanceWidget *pw = PerformanceWidget::Get();
+            if (pw)
+            {
+                pw->applyGraphWindowSeconds();
+                if (pw->IsActive())
+                    pw->onProviderUpdated();
+            }
+        });
+    }
+}
+
 void UIHelper::AddGraphContextMenuItems(QMenu *menu, QWidget *graphArea)
 {
     AddRefreshIntervalContextMenu(menu);
+    AddGraphWindowContextMenu(menu);
 
     menu->addSeparator();
-
     AddCopyWidgetAction(menu, graphArea, QObject::tr("Copy graph"));
 }
 

--- a/src/ui/uihelper.cpp
+++ b/src/ui/uihelper.cpp
@@ -144,26 +144,26 @@ void UIHelper::RestoreTableSelection(QTableView *view,
         vsb->setValue(snapshot.ScrollPos);
 }
 
-void UIHelper::PopulateRefreshIntervalMenu(QMenu *menu, QHash<QAction *, int> &intervalActions, QAction *&pausedAction)
-{
-    intervalActions.clear();
-    pausedAction = nullptr;
-    if (!menu)
-        return;
+// void UIHelper::PopulateRefreshIntervalMenu(QMenu *menu, QHash<QAction *, int> &intervalActions, QAction *&pausedAction)
+// {
+//     intervalActions.clear();
+//     pausedAction = nullptr;
+//     if (!menu)
+//         return;
 
-    for (int ms : CFG->RefreshRateAvailableIntervals)
-    {
-        QAction *a = menu->addAction(Misc::SimplifyTimeMS(ms));
-        a->setCheckable(true);
-        a->setChecked(!CFG->RefreshPaused && CFG->RefreshRateMs == ms);
-        intervalActions.insert(a, ms);
-    }
+//     for (int ms : CFG->RefreshRateAvailableIntervals)
+//     {
+//         QAction *a = menu->addAction(Misc::SimplifyTimeMS(ms));
+//         a->setCheckable(true);
+//         a->setChecked(!CFG->RefreshPaused && CFG->RefreshRateMs == ms);
+//         intervalActions.insert(a, ms);
+//     }
 
-    menu->addSeparator();
-    pausedAction = menu->addAction(QObject::tr("Paused"));
-    pausedAction->setCheckable(true);
-    pausedAction->setChecked(CFG->RefreshPaused);
-}
+//     menu->addSeparator();
+//     pausedAction = menu->addAction(QObject::tr("Paused"));
+//     pausedAction->setCheckable(true);
+//     pausedAction->setChecked(CFG->RefreshPaused);
+// }
 
 void UIHelper::AddGlobalContextMenuItems(QMenu *menu, QWidget *parent)
 {
@@ -230,31 +230,59 @@ void UIHelper::EnableCopyWidgetContextMenu(QWidget *widget, const QString &text)
     });
 }
 
-bool UIHelper::ApplyRefreshIntervalAction(QAction *picked,
-                                          const QHash<QAction *, int> &intervalActions,
-                                          QAction *pausedAction,
-                                          QTimer *timer,
-                                          bool timerOwnerActive)
+void UIHelper::AddRefreshIntervalContextMenu(QMenu *menu)
 {
-    if (!picked)
-        return false;
+    QMenu *refreshMenu = menu->addMenu(QObject::tr("Refresh interval"));
 
-    if (intervalActions.contains(picked))
+    QHash<QAction *, int> intervalActions;
+    intervalActions.clear();
+
+    for (int ms : CFG->RefreshRateAvailableIntervals)
     {
-        const int ms = intervalActions.value(picked);
-        CFG->RefreshPaused = false;
-        CFG->RefreshRateMs = ms;
-        Metrics::Get()->SetInterval(ms);
-        if (timer && timerOwnerActive)
-            timer->start(ms);
-        return true;
+        QAction *a = refreshMenu->addAction(Misc::SimplifyTimeMS(ms));
+        a->setCheckable(true);
+        a->setChecked(!CFG->RefreshPaused && CFG->RefreshRateMs == ms);
+        intervalActions.insert(a, ms);
+
+        QObject::connect(a, &QAction::triggered, menu, [=]()
+        {          
+            const int ms = intervalActions.value(a);
+            CFG->RefreshPaused = false;
+            CFG->RefreshRateMs = ms;
+            Metrics::Get()->SetInterval(ms);
+        });
     }
 
-    if (picked == pausedAction)
-    {
+    refreshMenu->addSeparator();
+
+    QAction *pausedAction = refreshMenu->addAction(QObject::tr("Paused"));
+    pausedAction->setCheckable(true);
+    pausedAction->setChecked(CFG->RefreshPaused);
+
+    QObject::connect(pausedAction, &QAction::triggered, []{
         CFG->RefreshPaused = true;
-        return true;
-    }
+    });
+}
 
-    return false;
+void UIHelper::AddGraphContextMenuItems(QMenu *menu, QWidget *graphArea)
+{
+    AddRefreshIntervalContextMenu(menu);
+
+    menu->addSeparator();
+
+    AddCopyWidgetAction(menu, graphArea, QObject::tr("Copy graph"));
+}
+
+void UIHelper::EnableGraphContextMenu(QWidget *widget)
+{
+    if (!widget)
+        return;
+
+    widget->setContextMenuPolicy(Qt::CustomContextMenu);
+    QObject::connect(widget, &QWidget::customContextMenuRequested, widget, [widget](const QPoint &pos)
+    {
+        QMenu menu(widget);
+        AddGraphContextMenuItems(&menu, widget);
+        menu.exec(widget->mapToGlobal(pos));
+    });
 }

--- a/src/ui/uihelper.cpp
+++ b/src/ui/uihelper.cpp
@@ -196,20 +196,6 @@ QAction *UIHelper::AddCopyWidgetAction(QMenu *menu, QWidget *widget, const QStri
     return copyAction;
 }
 
-void UIHelper::EnableCopyWidgetContextMenu(QWidget *widget, const QString &text)
-{
-    if (!widget)
-        return;
-
-    widget->setContextMenuPolicy(Qt::CustomContextMenu);
-    QObject::connect(widget, &QWidget::customContextMenuRequested, widget, [widget, text](const QPoint &pos)
-    {
-        QMenu menu(widget);
-        AddCopyWidgetAction(&menu, widget, text);
-        menu.exec(widget->mapToGlobal(pos));
-    });
-}
-
 void UIHelper::AddRefreshIntervalContextMenu(QMenu *menu, QTimer *timer, bool timerOwnerActive)
 {
     QMenu *refreshMenu = menu->addMenu(QObject::tr("Refresh interval"));

--- a/src/ui/uihelper.cpp
+++ b/src/ui/uihelper.cpp
@@ -145,27 +145,6 @@ void UIHelper::RestoreTableSelection(QTableView *view,
         vsb->setValue(snapshot.ScrollPos);
 }
 
-// void UIHelper::PopulateRefreshIntervalMenu(QMenu *menu, QHash<QAction *, int> &intervalActions, QAction *&pausedAction)
-// {
-//     intervalActions.clear();
-//     pausedAction = nullptr;
-//     if (!menu)
-//         return;
-
-//     for (int ms : CFG->RefreshRateAvailableIntervals)
-//     {
-//         QAction *a = menu->addAction(Misc::SimplifyTimeMS(ms));
-//         a->setCheckable(true);
-//         a->setChecked(!CFG->RefreshPaused && CFG->RefreshRateMs == ms);
-//         intervalActions.insert(a, ms);
-//     }
-
-//     menu->addSeparator();
-//     pausedAction = menu->addAction(QObject::tr("Paused"));
-//     pausedAction->setCheckable(true);
-//     pausedAction->setChecked(CFG->RefreshPaused);
-// }
-
 void UIHelper::AddGlobalContextMenuItems(QMenu *menu, QWidget *parent)
 {
     if (!menu)

--- a/src/ui/uihelper.cpp
+++ b/src/ui/uihelper.cpp
@@ -231,7 +231,7 @@ void UIHelper::EnableCopyWidgetContextMenu(QWidget *widget, const QString &text)
     });
 }
 
-void UIHelper::AddRefreshIntervalContextMenu(QMenu *menu)
+void UIHelper::AddRefreshIntervalContextMenu(QMenu *menu, QTimer *timer, bool timerOwnerActive)
 {
     QMenu *refreshMenu = menu->addMenu(QObject::tr("Refresh interval"));
 
@@ -245,12 +245,19 @@ void UIHelper::AddRefreshIntervalContextMenu(QMenu *menu)
         a->setChecked(!CFG->RefreshPaused && CFG->RefreshRateMs == ms);
         intervalActions.insert(a, ms);
 
-        QObject::connect(a, &QAction::triggered, menu, [=]()
+        QObject::connect(a, &QAction::triggered, menu, [menu, a, intervalActions, timer, timerOwnerActive]()
         {          
             const int ms = intervalActions.value(a);
             CFG->RefreshPaused = false;
             CFG->RefreshRateMs = ms;
             Metrics::Get()->SetInterval(ms);
+            PerformanceWidget *pw = PerformanceWidget::Get();
+            if (pw && pw->IsActive()) {
+                pw->onProviderUpdated();
+            }
+            if (timer && timerOwnerActive) {
+                timer->start(ms);
+            }
         });
     }
 
@@ -260,8 +267,15 @@ void UIHelper::AddRefreshIntervalContextMenu(QMenu *menu)
     pausedAction->setCheckable(true);
     pausedAction->setChecked(CFG->RefreshPaused);
 
-    QObject::connect(pausedAction, &QAction::triggered, []{
+    QObject::connect(pausedAction, &QAction::triggered, menu, [menu, timer, timerOwnerActive](){
         CFG->RefreshPaused = true;
+        PerformanceWidget *pw = PerformanceWidget::Get();
+        if (pw && pw->IsActive()) {
+            pw->onProviderUpdated();
+        }
+        if (timer && timerOwnerActive) {
+            timer->stop();
+        }
     });
 }
 

--- a/src/ui/uihelper.h
+++ b/src/ui/uihelper.h
@@ -69,8 +69,6 @@ namespace UIHelper
     void EnableCopyLabelContextMenu(QLabel *label);
     //! Adds a Copy graph action to an existing menu that copies the widget snapshot to the clipboard.
     QAction *AddCopyWidgetAction(QMenu *menu, QWidget *widget, const QString &text = QString());
-    //! Adds a context menu with a Copy graph action that copies the widget snapshot to the clipboard.
-    void EnableCopyWidgetContextMenu(QWidget *widget, const QString &text = QString());
 }
 
 #endif // UI_UIHELPER_H

--- a/src/ui/uihelper.h
+++ b/src/ui/uihelper.h
@@ -61,7 +61,7 @@ namespace UIHelper
     void AddGraphContextMenuItems(QMenu *menu, QWidget *graphArea);
     void EnableGraphContextMenu(QWidget *widget);
     void AddGraphWindowContextMenu(QMenu *menu);
-    void AddRefreshIntervalContextMenu(QMenu *menu);
+    void AddRefreshIntervalContextMenu(QMenu *menu, QTimer *timer = nullptr, bool timerOwnerActive = false);
     //! Adds a context menu with a Copy action that copies the label text to the clipboard.
     void EnableCopyLabelContextMenu(QLabel *label);
     //! Adds a Copy graph action to an existing menu that copies the widget snapshot to the clipboard.

--- a/src/ui/uihelper.h
+++ b/src/ui/uihelper.h
@@ -60,6 +60,7 @@ namespace UIHelper
     void AddGlobalContextMenuItems(QMenu *menu, QWidget *parent = nullptr);
     void AddGraphContextMenuItems(QMenu *menu, QWidget *graphArea);
     void EnableGraphContextMenu(QWidget *widget);
+    void AddGraphWindowContextMenu(QMenu *menu);
     void AddRefreshIntervalContextMenu(QMenu *menu);
     //! Adds a context menu with a Copy action that copies the label text to the clipboard.
     void EnableCopyLabelContextMenu(QLabel *label);

--- a/src/ui/uihelper.h
+++ b/src/ui/uihelper.h
@@ -56,7 +56,6 @@ namespace UIHelper
                                const std::function<QVariant(const QModelIndex &sourceKeyIndex)> &sourceKeyResolver,
                                const TableSelectionSnapshot &snapshot);
 
-    // void PopulateRefreshIntervalMenu(QMenu *menu, QHash<QAction *, int> &intervalActions, QAction *&pausedAction);
     void AddGlobalContextMenuItems(QMenu *menu, QWidget *parent = nullptr);
     void AddGraphContextMenuItems(QMenu *menu, QWidget *graphArea);
     void EnableGraphContextMenu(QWidget *widget);

--- a/src/ui/uihelper.h
+++ b/src/ui/uihelper.h
@@ -56,20 +56,17 @@ namespace UIHelper
                                const std::function<QVariant(const QModelIndex &sourceKeyIndex)> &sourceKeyResolver,
                                const TableSelectionSnapshot &snapshot);
 
-    void PopulateRefreshIntervalMenu(QMenu *menu, QHash<QAction *, int> &intervalActions, QAction *&pausedAction);
+    // void PopulateRefreshIntervalMenu(QMenu *menu, QHash<QAction *, int> &intervalActions, QAction *&pausedAction);
     void AddGlobalContextMenuItems(QMenu *menu, QWidget *parent = nullptr);
+    void AddGraphContextMenuItems(QMenu *menu, QWidget *graphArea);
+    void EnableGraphContextMenu(QWidget *widget);
+    void AddRefreshIntervalContextMenu(QMenu *menu);
     //! Adds a context menu with a Copy action that copies the label text to the clipboard.
     void EnableCopyLabelContextMenu(QLabel *label);
     //! Adds a Copy graph action to an existing menu that copies the widget snapshot to the clipboard.
     QAction *AddCopyWidgetAction(QMenu *menu, QWidget *widget, const QString &text = QString());
     //! Adds a context menu with a Copy graph action that copies the widget snapshot to the clipboard.
     void EnableCopyWidgetContextMenu(QWidget *widget, const QString &text = QString());
-
-    bool ApplyRefreshIntervalAction(QAction *picked,
-                                    const QHash<QAction *, int> &intervalActions,
-                                    QAction *pausedAction,
-                                    QTimer *timer = nullptr,
-                                    bool timerOwnerActive = true);
 }
 
 #endif // UI_UIHELPER_H

--- a/src/ui/uihelper.h
+++ b/src/ui/uihelper.h
@@ -57,9 +57,13 @@ namespace UIHelper
                                const TableSelectionSnapshot &snapshot);
 
     void AddGlobalContextMenuItems(QMenu *menu, QWidget *parent = nullptr);
+    //! Adds context actions relevant to graphs to a context menu.
     void AddGraphContextMenuItems(QMenu *menu, QWidget *graphArea);
+    //! Adds context menu relevant to graphs to a widget.
     void EnableGraphContextMenu(QWidget *widget);
+    //! Adds a "Graph time" contex menu to an existing menu that gives options to change the timespan of a graph.
     void AddGraphWindowContextMenu(QMenu *menu);
+    //! Adds a "Refresh interval" contex menu to an existing menu that gives options to change the refresh rate.
     void AddRefreshIntervalContextMenu(QMenu *menu, QTimer *timer = nullptr, bool timerOwnerActive = false);
     //! Adds a context menu with a Copy action that copies the label text to the clipboard.
     void EnableCopyLabelContextMenu(QLabel *label);

--- a/src/userswidget.cpp
+++ b/src/userswidget.cpp
@@ -193,8 +193,6 @@ void UsersWidget::onRefreshFinished(int consumer, quint64 token, const QList<OS:
 void UsersWidget::onContextMenu(const QPoint &pos)
 {
     QMenu menu(this);
-    QHash<QAction *, int> refreshIntervalActions;
-    QAction *pausedRefreshAction = nullptr;
 
     const QTreeWidgetItem *item = this->ui->treeWidget->itemAt(pos);
     const bool isProcessItem = item && item->parent();
@@ -212,12 +210,10 @@ void UsersWidget::onContextMenu(const QPoint &pos)
         menu.addSeparator();
     }
 
-    QMenu *refreshMenu = menu.addMenu(tr("Refresh interval"));
-    UIHelper::PopulateRefreshIntervalMenu(refreshMenu, refreshIntervalActions, pausedRefreshAction);
+    UIHelper::AddRefreshIntervalContextMenu(&menu);
     UIHelper::AddGlobalContextMenuItems(&menu, this);
 
-    QAction *picked = menu.exec(this->ui->treeWidget->viewport()->mapToGlobal(pos));
-    UIHelper::ApplyRefreshIntervalAction(picked, refreshIntervalActions, pausedRefreshAction, this->m_refreshTimer, this->m_active);
+    menu.exec(this->ui->treeWidget->viewport()->mapToGlobal(pos));
 }
 
 void UsersWidget::rebuildTree(const QList<OS::Process> &allProcs)

--- a/src/userswidget.cpp
+++ b/src/userswidget.cpp
@@ -210,7 +210,7 @@ void UsersWidget::onContextMenu(const QPoint &pos)
         menu.addSeparator();
     }
 
-    UIHelper::AddRefreshIntervalContextMenu(&menu);
+    UIHelper::AddRefreshIntervalContextMenu(&menu, this->m_refreshTimer, this->m_active);
     UIHelper::AddGlobalContextMenuItems(&menu, this);
 
     menu.exec(this->ui->treeWidget->viewport()->mapToGlobal(pos));


### PR DESCRIPTION
Made the `refresh interval` and `graph time` context menu options be available not only from the side panel, but also from clicking on the graphs. 