### PR TITLE
Performance: make side panel resizable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Future
   * Memory view now shows compressed memory when zswap is used
   * Implemented Intel GPU backend
+  * Performance side panel is now resizable
 
 # 1.0.5
   * Perf -> Network:

--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -132,6 +132,7 @@ void Configuration::Load()
     this->PerfNetworkUseBits =  s.value("Performance/NetworkUseBits",    this->PerfNetworkUseBits).toBool();
     this->PerfGraphWindowSec =  s.value("Performance/GraphWindowSec",    this->PerfGraphWindowSec).toInt();
     this->PerfSidePanelGroupOrder = s.value("Performance/SidePanelGroupOrder", this->PerfSidePanelGroupOrder).toStringList();
+    this->PerformanceSplitterState = s.value("Performance/SplitterState",     this->PerformanceSplitterState).toByteArray();
 
     // For now this is hardcoded, we may want to make it customizable later
     this->RefreshRateAvailableIntervals = { 250, 500, 1000, 2000, 5000, 15000 };
@@ -203,6 +204,7 @@ void Configuration::Save()
     s.setValue("Performance/NetworkUseBits",            this->PerfNetworkUseBits);
     s.setValue("Performance/GraphWindowSec",            this->PerfGraphWindowSec);
     s.setValue("Performance/SidePanelGroupOrder",       this->PerfSidePanelGroupOrder);
+    s.setValue("Performance/SplitterState",             this->PerformanceSplitterState);
 
     s.sync();
 }

--- a/src/configuration.h
+++ b/src/configuration.h
@@ -96,6 +96,7 @@ class Configuration : public QObject
         bool PerfNetworkUseBits { true };
         int PerfGraphWindowSec { 60 };
         QStringList PerfSidePanelGroupOrder;
+        QByteArray PerformanceSplitterState;   ///< Saved via QSplitter::saveState()
 
     private:
         explicit Configuration(QObject *parent = nullptr);

--- a/src/perf/sidepanel.cpp
+++ b/src/perf/sidepanel.cpp
@@ -48,7 +48,6 @@ SidePanel::SidePanel(QWidget *parent) : QWidget(parent)
     this->setLayout(outerLayout);
 
     this->setMinimumWidth(150);
-    this->setMaximumWidth(200);
 }
 
 void SidePanel::ApplyColorScheme()

--- a/src/performancewidget.cpp
+++ b/src/performancewidget.cpp
@@ -37,6 +37,7 @@
 #include <QMenu>
 #include <QPalette>
 #include <QRegularExpression>
+#include <QSplitter>
 
 namespace
 {
@@ -134,15 +135,25 @@ void PerformanceWidget::setupLayout()
     // The .ui gives us a bare QHBoxLayout (horizontalLayout) — populate it.
     QHBoxLayout *lay = qobject_cast<QHBoxLayout *>(this->layout());
 
-    lay->addWidget(this->m_sidePanel);
+    this->m_splitter = new QSplitter(Qt::Horizontal, this);
+    this->m_splitter->setChildrenCollapsible(false);
+    this->m_splitter->addWidget(this->m_sidePanel);
+    this->m_splitter->addWidget(this->m_stack);
+    this->m_splitter->setStretchFactor(0, 0);
+    this->m_splitter->setStretchFactor(1, 1);
 
-    // Thin separator line
-    QFrame *separator = new QFrame(this);
-    separator->setFrameShape(QFrame::VLine);
-    separator->setFrameShadow(QFrame::Sunken);
-    lay->addWidget(separator);
+    const QByteArray saved_state = CFG->PerformanceSplitterState;
+    if (!saved_state.isEmpty())
+        this->m_splitter->restoreState(saved_state);
+    else
+        this->m_splitter->setSizes({ 220, 680 });
 
-    lay->addWidget(this->m_stack, /*stretch=*/1);
+    connect(this->m_splitter, &QSplitter::splitterMoved, this, [this](int, int)
+    {
+        CFG->PerformanceSplitterState = this->m_splitter->saveState();
+    });
+
+    lay->addWidget(this->m_splitter);
 }
 
 void PerformanceWidget::setupSidePanel()

--- a/src/performancewidget.h
+++ b/src/performancewidget.h
@@ -29,6 +29,7 @@
 
 #include <QHash>
 #include <QPoint>
+#include <QSplitter>
 #include <QStackedWidget>
 #include <QVector>
 #include <QWidget>
@@ -56,6 +57,7 @@ class PerformanceWidget : public QWidget
         Ui::PerformanceWidget      *ui;
         Perf::SidePanel            *m_sidePanel;
         QStackedWidget             *m_stack;
+        QSplitter                  *m_splitter { nullptr };
         QHash<Perf::SidePanelItem *, QWidget *> m_detailByItem;
         Perf::SidePanelItem        *m_cpuItem { nullptr };
         Perf::SidePanelItem        *m_memoryItem { nullptr };


### PR DESCRIPTION
## Summary

  On displays where the Performance tab's right pane has a large minimum
  size, the side panel summaries get truncated (e.g. `...GB/31.2 GB (22%)`
  for memory) and there's no way for the user to widen the panel.

  This PR makes the side panel user-resizable via a `QSplitter` and
  persists the chosen size across sessions. Similar functionally to how modern
  versions of Windows Task Manager handle it.

  ## Changes

  - Replace the static `QHBoxLayout` in `PerformanceWidget::setupLayout()`
    with a horizontal `QSplitter` (`setChildrenCollapsible(false)`).
    The splitter handle replaces the manual `QFrame::VLine` separator.
  - Persist splitter state via `Configuration::PerformanceSplitterState`
    (key `Performance/SplitterState`), following the existing
    `QByteArray` + `QSettings` pattern used for `WindowGeometry`,
    `ProcessListHeaderState`, etc.
  - Drop `setMaximumWidth(200)` from `Perf::SidePanel`. The splitter now
    governs width; the side panel's existing `setMinimumWidth(150)`
    remains as the floor, and the right pane's `minimumSizeHint()` is
    the natural ceiling.
  - Default to 220 px on first run (This might be too big on some displays? Open to 
    suggestions).  I was thinking about maybe calculating the default size to be the 
    smallest size it could be without causing the text to be truncated. If this seems 
    like a good idea I can submit a follow up PR.
    


  Old  (2560x1440, 100% display scale)
    
<img width="178" height="579" alt="Screenshot_20260508_194923" src="https://github.com/user-attachments/assets/fdf2c9dd-ea62-49e0-b32e-78a35d05de06" />



 New


<img width="298" height="614" alt="image" src="https://github.com/user-attachments/assets/99a620dd-7f0b-463e-beaf-0939bf21d544" />
   
    
    
    