### PR TITLE
update graph tooltip when not moving

### DIFF
--- a/src/perf/gpudetailwidget.cpp
+++ b/src/perf/gpudetailwidget.cpp
@@ -112,7 +112,6 @@ GpuDetailWidget::GpuDetailWidget(QWidget *parent) : QWidget(parent), ui(new Ui::
     configureGraph(this->ui->copyBwGraphWidget);
     this->ui->copyBwGraphWidget->SetSeriesNames(tr("TX"), tr("RX"));
     this->ui->copyBwGraphWidget->SetValueFormat(GraphWidget::ValueFormat::BytesPerSec);
-    this->ui->copyBwGraphWidget->setToolTip(tr("Copy bandwidth: light trace = TX, dark trace = RX"));
     UIHelper::EnableCopyWidgetContextMenu(this->ui->copyBwGraphWidget);
 
     UIHelper::EnableCopyLabelContextMenu(this->ui->utilValueLabel);

--- a/src/perf/graphwidget.cpp
+++ b/src/perf/graphwidget.cpp
@@ -275,6 +275,9 @@ void GraphWidget::paintEvent(QPaintEvent * /*event*/)
         p.setPen(QPen(hover, 1));
         p.drawLine(QPointF(x, contentTop), QPointF(x, contentBottom));
     }
+
+    if (this->m_isHovered)
+        updateTooltip();
 }
 
 void GraphWidget::mouseMoveEvent(QMouseEvent *event)
@@ -296,41 +299,14 @@ void GraphWidget::mouseMoveEvent(QMouseEvent *event)
         this->update(oldRect.united(this->hoverLineRect(this->m_hoverSlot)));
     }
 
-    if (this->m_hoverTooltipEnabled && slotChanged)
-    {
-        const int idx1 = sampleIndexForSlot(this->m_data ? this->m_data->Size() : 0, slot, sampleCount);
-        const int idx2 = sampleIndexForSlot(this->m_overlayData ? this->m_overlayData->Size() : 0, slot, sampleCount);
-
-        if (idx1 >= 0 || idx2 >= 0)
-        {
-            QString tip;
-            if (idx1 >= 0)
-                tip += tr("%1: %2").arg(this->m_primaryName, this->formatValue(this->m_data->At(idx1)));
-            if (idx2 >= 0)
-            {
-                if (!tip.isEmpty())
-                    tip += "\n";
-                tip += tr("%1: %2").arg(this->m_secondaryName, this->formatValue(this->m_overlayData->At(idx2)));
-            }
-            const int secAgo = sampleCount - 1 - slot;
-            if (!tip.isEmpty())
-                tip += tr("\n%1 s ago").arg(secAgo);
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-            QToolTip::showText(event->globalPosition().toPoint(), tip, this);
-#else
-            QToolTip::showText(event->globalPos(), tip, this);
-#endif
-        } else
-        {
-            QToolTip::hideText();
-        }
-    }
+    this->m_isHovered = true;
 
     QWidget::mouseMoveEvent(event);
 }
 
 void GraphWidget::leaveEvent(QEvent *event)
 {
+    this->m_isHovered = false;
     const QRect oldRect = this->hoverLineRect(this->m_hoverSlot);
     this->m_hoverSlot = -1;
     if (this->m_hoverTooltipEnabled)
@@ -392,5 +368,39 @@ QString GraphWidget::formatValue(double v) const
             if (this->m_maxVal <= 100.0)
                 return QString::number(v, 'f', 1) + tr("%");
             return QString::number(v, 'f', 2);
+    }
+}
+
+void GraphWidget::updateTooltip()
+{
+    if (this->m_hoverTooltipEnabled)
+    {
+        const int sampleCount = qMax(2, this->m_sampleCapacity);
+        const double stepX = static_cast<double>(qMax(1, this->width())) / static_cast<double>(sampleCount - 1);
+        const double mouseX = mapFromGlobal(QCursor::pos()).x();
+        const int slot = qBound(0, static_cast<int>(std::lround(mouseX / stepX)), sampleCount - 1);
+
+        const int idx1 = sampleIndexForSlot(this->m_data ? this->m_data->Size() : 0, slot, sampleCount);
+        const int idx2 = sampleIndexForSlot(this->m_overlayData ? this->m_overlayData->Size() : 0, slot, sampleCount);
+
+        if (idx1 >= 0 || idx2 >= 0)
+        {
+            QString tip;
+            if (idx1 >= 0)
+                tip += tr("%1: %2").arg(this->m_primaryName, this->formatValue(this->m_data->At(idx1)));
+            if (idx2 >= 0)
+            {
+                if (!tip.isEmpty())
+                    tip += "\n";
+                tip += tr("%1: %2").arg(this->m_secondaryName, this->formatValue(this->m_overlayData->At(idx2)));
+            }
+            const int secAgo = sampleCount - 1 - slot;
+            if (!tip.isEmpty())
+                tip += tr("\n%1 s ago").arg(secAgo);
+            QToolTip::showText(QCursor::pos(), tip, this);
+        } else
+        {
+            QToolTip::hideText();
+        }
     }
 }

--- a/src/perf/graphwidget.h
+++ b/src/perf/graphwidget.h
@@ -116,6 +116,7 @@ namespace Perf
             bool            m_gridEnabled { true };
             int             m_sampleCapacity { 60 };  ///< Matches the default history window in seconds.
             int             m_historyTick { 0 };      ///< Advances as samples arrive; used for grid phase.
+            bool            m_isHovered { false };
             int             m_hoverSlot { -1 };
             bool            m_hoverLineEnabled { true };
             bool            m_hoverTooltipEnabled { true };
@@ -131,6 +132,7 @@ namespace Perf
             QRect hoverLineRect(int slot) const;
             static int sampleIndexForSlot(int size, int slot, int sampleCount);
             QString formatValue(double v) const;
+            void updateTooltip();
     };
 } // namespace Perf
 


### PR DESCRIPTION
Previously, the graph tooltip only got updated when it was moved left/right. This pr fixes that.