### PR TITLE
Make the process tree hiearchy clearer

### DIFF
--- a/src/os/processtreemodel.cpp
+++ b/src/os/processtreemodel.cpp
@@ -148,7 +148,6 @@ QVariant ProcessTreeModel::data(const QModelIndex &index, int role) const
     {
         switch (static_cast<Column>(index.column()))
         {
-            case ColPid:
             case ColCpu:
             case ColMemRss:
             case ColMemVirt:

--- a/src/processeswidget.cpp
+++ b/src/processeswidget.cpp
@@ -296,6 +296,8 @@ void ProcessesWidget::setupTable()
     this->m_treeView->setColumnHidden(OS::ProcessTreeModel::ColIoWrites, true);
     this->m_treeView->setColumnHidden(OS::ProcessTreeModel::ColIoReadsPerSec, true);
     this->m_treeView->setColumnHidden(OS::ProcessTreeModel::ColIoWritesPerSec, true);
+    connect(this->m_treeView, &QTreeView::expanded, this, [this]() { this->m_treeView->resizeColumnToContents(OS::ProcessTreeModel::ColPid); });
+    connect(this->m_treeView, &QTreeView::collapsed, this, [this]() { this->m_treeView->resizeColumnToContents(OS::ProcessTreeModel::ColPid); });
     if (!CFG->ProcessTreeHeaderState.isEmpty())
     {
         treeHeader->restoreState(CFG->ProcessTreeHeaderState);

--- a/src/processeswidget.cpp
+++ b/src/processeswidget.cpp
@@ -302,6 +302,7 @@ void ProcessesWidget::setupTable()
     {
         treeHeader->restoreState(CFG->ProcessTreeHeaderState);
     }
+    treeHeader->setSectionResizeMode(OS::ProcessTreeModel::ColPid, QHeaderView::Fixed);
     this->syncAllProcessColumnVisibility();
     this->m_treeHeaderPersistenceEnabled = true;
     connect(this->m_treeView, &QTreeView::customContextMenuRequested, this, &ProcessesWidget::onTreeContextMenu);

--- a/src/processeswidget.cpp
+++ b/src/processeswidget.cpp
@@ -275,7 +275,6 @@ void ProcessesWidget::setupTable()
     });
     connect(treeHeader, &QHeaderView::sectionMoved, this, [this]() { this->saveTreeHeaderState(); });
     connect(treeHeader, &QHeaderView::sectionResized, this, [this]() { this->saveTreeHeaderState(); });
-    this->m_treeView->setColumnWidth(OS::ProcessTreeModel::ColPid, 60);
     this->m_treeView->setColumnWidth(OS::ProcessTreeModel::ColName, 160);
     this->m_treeView->setColumnWidth(OS::ProcessTreeModel::ColUser, 90);
     this->m_treeView->setColumnWidth(OS::ProcessTreeModel::ColState, 90);
@@ -317,7 +316,10 @@ void ProcessesWidget::setTreeViewMode(bool enabled)
     CFG->ProcessTreeView = enabled;
 
     if (enabled)
+    {
         this->m_treeModel->SetProcesses(this->m_lastProcessSnapshot.isEmpty() ? this->m_model->GetProcesses() : this->m_lastProcessSnapshot);
+        this->m_treeView->resizeColumnToContents(OS::ProcessTreeModel::ColPid);
+    }
 
     if (!this->m_viewStack)
         return;


### PR DESCRIPTION
- Automatically resizes the pid column so that deeply nested parts become visible. Previously, the PID numbers vanished and you couldn't see the expand/collapse icon if you went deep enough. 
- Aligned the pid number to the left, making the hierarchy clearer.