### PR TITLE
SidePanelItem selection is themed; PerformanceWidget is scrolled.

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -20,6 +20,17 @@
 #include "ui_mainwindow.h"
 #include "configuration.h"
 
+#include <QDebug>
+#include <QWidget>
+#include <QLayout>
+#include <QLayoutItem>
+
+#include <QDebug>
+#include <QWidget>
+#include <QLayout>
+#include <QLayoutItem>
+#include <QTabWidget>
+
 MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent)
     , ui(new Ui::MainWindow)
     , m_processRefreshService(new OS::ProcessRefreshService(this))

--- a/src/perf/sidepanelitem.cpp
+++ b/src/perf/sidepanelitem.cpp
@@ -23,6 +23,8 @@
 
 #include <QPainter>
 #include <QPaintEvent>
+#include <QStyle>
+#include <QStyleOption>
 #include <QVBoxLayout>
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 #include <QEnterEvent>
@@ -90,20 +92,30 @@ void SidePanelItem::paintEvent(QPaintEvent *event)
 
     const QRect r = this->rect();
 
-    // Background
-    QColor bg;
-    if (this->m_selected)
-    {
-        bg = scheme->SidePanelItemSelectedBackgroundColor;
-    } else if (this->m_hovered)
-    {
-        bg = scheme->SidePanelItemHoverBackgroundColor;
-    } else
-    {
-        bg = scheme->SidePanelItemBackgroundColor;
+    // Selection bg
+
+    QStyleOptionViewItem option;
+    option.initFrom(this);
+
+    if (this->m_selected) {
+        option.state |= QStyle::State_Selected;
+
+        // If window loses focus, drop State_Active to trigger the GRAY look
+        if (this->isActiveWindow() && this->hasFocus()) {
+            option.state |= QStyle::State_Active;
+        }
+    } else {
+        // Not selected, but window must be active to show the BLUE hover look
+        if (this->isActiveWindow()) {
+            option.state |= QStyle::State_Active;
+        }
     }
 
-    p.fillRect(r, bg);
+    if (this->m_hovered) {
+        option.state |= QStyle::State_MouseOver;
+    }
+
+    style()->drawPrimitive(QStyle::PE_PanelItemViewItem, &option, &p, nullptr);
 
     // Title/subtitle (single row): elide both sides to prevent overlap.
     QFont titleFont = this->font();
@@ -140,14 +152,6 @@ void SidePanelItem::paintEvent(QPaintEvent *event)
         p.drawText(QRect(r.width() - right - subW, top, subW, textH),
                    Qt::AlignRight | Qt::AlignVCenter,
                    subText);
-    }
-
-    // Selection border
-    if (this->m_selected)
-    {
-        p.setPen(QPen(scheme->SidePanelItemSelectedBorderColor, 2));
-        p.setBrush(Qt::NoBrush);
-        p.drawRect(r.adjusted(1, 1, -1, -1));
     }
 }
 

--- a/src/performancewidget.cpp
+++ b/src/performancewidget.cpp
@@ -38,6 +38,7 @@
 #include <QPalette>
 #include <QPainter>
 #include <QRegularExpression>
+#include <QScrollArea>
 #include <QSplitter>
 #include <QSplitterHandle>
 
@@ -187,7 +188,13 @@ void PerformanceWidget::setupLayout()
     this->m_splitter = new PerformanceSplitter(this);
     this->m_splitter->setChildrenCollapsible(false);
     this->m_splitter->addWidget(this->m_sidePanel);
-    this->m_splitter->addWidget(this->m_stack);
+
+    auto *scrollArea = new QScrollArea;
+    scrollArea->setFrameShape(QFrame::NoFrame);
+    scrollArea->setWidgetResizable(true);
+    scrollArea->setWidget(this->m_stack);
+    this->m_splitter->addWidget(scrollArea);
+
     this->m_splitter->setStretchFactor(0, 0);
     this->m_splitter->setStretchFactor(1, 1);
 


### PR DESCRIPTION
I changed the drawing code for `SidePanelItem` so that the background is drawn using the active theme and looks more native. For example on my Windows 7 theme:

<img width="216" height="277" alt="image" src="https://github.com/user-attachments/assets/743f1fb0-defb-48c0-bde4-801fa69ff276" />

I also wrapped the right pane inside the PerformanceWidget in a `QScrollArea` so that the app window can be resized below 600x800.