### PR TITLE
Support openSUSE in RPM packaging script

### DIFF
--- a/packaging/README.md
+++ b/packaging/README.md
@@ -5,7 +5,7 @@ This directory contains Linux packaging scripts for Tux Manager.
 ## Supported targets
 
 - Debian/Ubuntu (`.deb`) via `package-deb.sh`
-- Fedora/RHEL/Alma/Rocky (`.rpm` + `.src.rpm`) via `package-rpm.sh`
+- Fedora/RHEL/Alma/Rocky/openSUSE (`.rpm` + `.src.rpm`) via `package-rpm.sh`
 - AppImage (`.AppImage`) via `package-appimage.sh`
 - Arch Linux (`.pkg.tar.*`) via `package-arch.sh`
 - Arch Linux / AUR metadata via `arch/PKGBUILD`, `.SRCINFO`, and `.github/workflows/build-arch-aur.yml`
@@ -38,6 +38,19 @@ sudo dnf install rpm-build rsync git pkgconf-pkg-config qt6-qtbase-devel
 Notes:
 - The script can also build with Qt5 if only that is available (`qt5-qtbase-devel`).
 - The script uses `rpmbuild` and creates both binary RPM and source RPM.
+
+### openSUSE
+
+Required build tools/packages:
+
+```bash
+sudo zypper install rpm-build git gzip pkgconf-pkg-config \
+  qt6-base-common-devel qt6-core-devel qt6-gui-devel qt6-widgets-devel
+```
+
+Notes:
+- The same `package-rpm.sh` script detects openSUSE and uses its Qt 6 package names.
+- The script creates both a binary RPM and a source RPM.
 
 ### Flatpak
 
@@ -223,10 +236,12 @@ sudo dpkg -i packaging/output/tux-manager_*.deb
 sudo apt-get install -f
 ```
 
-### Fedora/RHEL family
+### Fedora/RHEL family and openSUSE
 
 ```bash
 sudo dnf install packaging/output/tux-manager-*.rpm
+# or, on openSUSE:
+sudo zypper install packaging/output/tux-manager-*.rpm
 ```
 
 ### Flatpak

--- a/packaging/package-rpm.sh
+++ b/packaging/package-rpm.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 ################################################################################
-# package-rpm.sh - Build and package Tux Manager for Fedora/RHEL/CentOS
+# package-rpm.sh - Build and package Tux Manager for RPM-based distributions
 ################################################################################
 
 set -e
@@ -11,6 +11,12 @@ source "$SCRIPT_DIR/config"
 QT_BIN_PATH=""
 NCPUS=$(nproc)
 RELEASE="1"
+
+if command -v zypper >/dev/null 2>&1; then
+    RPM_FAMILY="opensuse"
+else
+    RPM_FAMILY="redhat"
+fi
 
 while [[ $# -gt 0 ]]; do
     case $1 in
@@ -51,6 +57,11 @@ pkg_available() {
         yum -q list available "$pkg" >/dev/null 2>&1
         return $?
     fi
+    if command -v zypper >/dev/null 2>&1; then
+        zypper --non-interactive search --match-exact --type package "$pkg" 2>/dev/null |
+            grep -qE "^[[:space:]]*i?[[:space:]]*\\|[[:space:]]*$pkg[[:space:]]*\\|"
+        return $?
+    fi
     return 1
 }
 
@@ -76,11 +87,20 @@ if command -v rpm >/dev/null 2>&1; then
     }
 
     require_pkg rpm-build
-    require_pkg rsync
     require_pkg git
+    require_pkg gzip
     require_pkg pkgconf-pkg-config
 
-    if [ "$QT_MAJOR" -eq 5 ]; then
+    if [ "$RPM_FAMILY" = "opensuse" ]; then
+        if [ "$QT_MAJOR" -eq 5 ]; then
+            require_pkg libqt5-qtbase-devel
+        else
+            require_pkg qt6-base-common-devel
+            require_pkg qt6-core-devel
+            require_pkg qt6-gui-devel
+            require_pkg qt6-widgets-devel
+        fi
+    elif [ "$QT_MAJOR" -eq 5 ]; then
         require_pkg qt5-qtbase-devel
     else
         require_pkg qt6-qtbase-devel
@@ -93,6 +113,8 @@ if command -v rpm >/dev/null 2>&1; then
             echo "  sudo dnf install ${missing[*]}"
         elif command -v yum >/dev/null 2>&1; then
             echo "  sudo yum install ${missing[*]}"
+        elif command -v zypper >/dev/null 2>&1; then
+            echo "  sudo zypper install ${missing[*]}"
         else
             for pkg in "${missing[@]}"; do
                 echo "  - $pkg"
@@ -184,10 +206,18 @@ License:        GPL-3.0-or-later
 URL:            https://github.com/benapetr/TuxManager
 Source0:        %{name}-%{version}.tar.gz
 
+%if 0%{?suse_version}
+%if 0%{?qt_major} == 5
+BuildRequires:  pkgconfig(Qt5Widgets)
+%else
+BuildRequires:  pkgconfig(Qt6Widgets)
+%endif
+%else
 %if 0%{?qt_major} == 5
 BuildRequires:  qt5-qtbase-devel
 %else
 BuildRequires:  qt6-qtbase-devel
+%endif
 %endif
 BuildRequires:  pkgconf-pkg-config
 
@@ -200,7 +230,10 @@ Tux Manager is a Linux system monitor inspired by Windows Task Manager.
 %build
 mkdir -p release
 pushd src
-%{qmake_cmd} TuxManager.pro -o ../release/Makefile
+%{qmake_cmd} TuxManager.pro -o ../release/Makefile \
+    QMAKE_CFLAGS="%{optflags}" \
+    QMAKE_CXXFLAGS="%{optflags}" \
+    QMAKE_LFLAGS="%{?build_ldflags} -Wl,--as-needed"
 popd
 %make_build -C release
 
@@ -234,8 +267,19 @@ rpmbuild --define "_topdir $RPM_BUILD_ROOT" \
 
 OUTPUT_DIR="$PROJECT_ROOT/packaging/output"
 mkdir -p "$OUTPUT_DIR"
-cp "$RPM_BUILD_ROOT/RPMS/x86_64/${APP_NAME}-${APP_VERSION}-${RELEASE}"*.rpm "$OUTPUT_DIR/"
-cp "$RPM_BUILD_ROOT/SRPMS/${APP_NAME}-${APP_VERSION}-${RELEASE}"*.src.rpm "$OUTPUT_DIR/"
+shopt -s nullglob
+artifacts=(
+    "$RPM_BUILD_ROOT"/RPMS/*/"${APP_NAME}-${APP_VERSION}-${RELEASE}"*.rpm
+    "$RPM_BUILD_ROOT"/SRPMS/"${APP_NAME}-${APP_VERSION}-${RELEASE}"*.src.rpm
+)
+shopt -u nullglob
+
+if [ ${#artifacts[@]} -eq 0 ]; then
+    echo "Error: rpmbuild completed but no RPM artifacts were found."
+    exit 1
+fi
+
+cp "${artifacts[@]}" "$OUTPUT_DIR/"
 
 echo ""
 echo "==============================="
@@ -245,7 +289,11 @@ echo "Binary RPM: $OUTPUT_DIR/${APP_NAME}-${APP_VERSION}-${RELEASE}*.rpm"
 echo "Source RPM: $OUTPUT_DIR/${APP_NAME}-${APP_VERSION}-${RELEASE}*.src.rpm"
 echo ""
 echo "To install:"
-echo "  sudo dnf install $OUTPUT_DIR/${APP_NAME}-${APP_VERSION}-${RELEASE}*.rpm"
-echo "  # or"
-echo "  sudo rpm -ivh $OUTPUT_DIR/${APP_NAME}-${APP_VERSION}-${RELEASE}*.rpm"
+if [ "$RPM_FAMILY" = "opensuse" ]; then
+    echo "  sudo zypper install $OUTPUT_DIR/${APP_NAME}-${APP_VERSION}-${RELEASE}.$(rpm --eval '%{_arch}').rpm"
+else
+    echo "  sudo dnf install $OUTPUT_DIR/${APP_NAME}-${APP_VERSION}-${RELEASE}*.rpm"
+    echo "  # or"
+    echo "  sudo rpm -ivh $OUTPUT_DIR/${APP_NAME}-${APP_VERSION}-${RELEASE}*.rpm"
+fi
 echo ""


### PR DESCRIPTION
## Summary

- extend the existing `packaging/package-rpm.sh` workflow to support openSUSE
- detect openSUSE and use its Qt development package names and `zypper` guidance
- use capability-based Qt `BuildRequires` on SUSE while preserving Fedora/RHEL package requirements
- apply RPM build flags and discover output artifacts without assuming `x86_64`
- document openSUSE dependencies and installation through the shared RPM workflow

This supersedes #64 and avoids adding a distribution-specific packaging script.

## Verification

- `bash -n packaging/package-rpm.sh`
- completed an end-to-end build with `packaging/package-rpm.sh` on openSUSE
- produced and inspected `tux-manager-1.0.7-1.x86_64.rpm` and `tux-manager-1.0.7-1.src.rpm`
- installed and tested the resulting binary RPM successfully on openSUSE