### PR TITLE
Fix Nix build: point qmake at qttools' lrelease binary

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -28,7 +28,12 @@
             nativeBuildInputs = with pkgs.kdePackages; [ qmake qttools wrapQtAppsHook ];
             buildInputs = with pkgs.kdePackages; [ qtbase ];
 
-            configurePhase = "qmake6 $src/src";
+            # qmake's qtPrepareTool() hardcodes tool lookups to qtbase's own store
+            # path at mkspecs-generation time, but nixpkgs ships lrelease in
+            # kdePackages.qttools instead. Point it at the real binary explicitly.
+            configurePhase = ''
+              qmake6 $src/src "QT_TOOL.lrelease.binary=${pkgs.kdePackages.qttools}/bin/lrelease"
+            '';
             buildPhase = "make -j$NIX_BUILD_CORES";
 
             installPhase = ''


### PR DESCRIPTION
qmake's qtPrepareTool() macro hardcodes tool lookups (like lrelease) to qtbase's own store output at mkspecs-generation time. On nixpkgs, lrelease lives in kdePackages.qttools instead, which is a separate derivation, so the build failed with "No such file or directory" once CONFIG += lrelease was introduced. Pass QT_TOOL.lrelease.binary explicitly on the qmake command line to point at the real binary.

This was broken by #71